### PR TITLE
Adds SQLite DB with build script

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,29 +1,31 @@
 {
-    "name": "focus-help-center-api",
-    "version": "0.1.0",
-    "description": "API for the Focus help center",
-    "main": "./dist/index.js",
-    "scripts": {
-        "build": "gulp build",
-        "watch": "gulp watch",
-        "postinstall": "typings install",
-        "start": "node dist/index.js",
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "author": "KleeGroup",
-    "license": "MIT",
-    "dependencies": {
-        "express": "4.13.4",
-        "lodash": "4.13.1",
-        "sequelize": "3.23.3"
-    },
-    "devDependencies": {
-        "babel-cli": "6.9.0",
-        "babel-preset-node6": "11.0.0",
-        "gulp": "^3.9.1",
-        "gulp-babel": "^6.1.2",
-        "gulp-typescript": "^2.13.5",
-        "typescript": "1.8.10",
-        "typings": "1.0.4"
-    }
+  "name": "focus-help-center-api",
+  "version": "0.1.0",
+  "description": "API for the Focus help center",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "gulp build",
+    "buildDb": "node ./dist/db/init.js",
+    "postinstall": "typings install && gulp build && node ./dist/db/init.js",
+    "start": "node dist/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "watch": "gulp watch"
+  },
+  "author": "KleeGroup",
+  "license": "MIT",
+  "dependencies": {
+    "express": "4.13.4",
+    "lodash": "4.13.1",
+    "sequelize": "3.23.3",
+    "sqlite3": "3.1.4"
+  },
+  "devDependencies": {
+    "babel-cli": "6.9.0",
+    "babel-preset-node6": "11.0.0",
+    "gulp": "3.9.1",
+    "gulp-babel": "6.1.2",
+    "gulp-typescript": "2.13.5",
+    "typescript": "1.8.10",
+    "typings": "1.0.4"
+  }
 }

--- a/api/src/db/article.d.ts
+++ b/api/src/db/article.d.ts
@@ -1,0 +1,13 @@
+import Sequelize from 'sequelize';
+
+/** Represents an article. */
+interface IArticle {
+    title: string;
+    description: string;
+    content: string;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+/** Represents the article instance for the ORM (ie the object returned by queries) */
+interface IArticleInstance extends Sequelize.Instance<{}, IArticle> { }

--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -1,0 +1,22 @@
+import Sequelize from 'sequelize';
+import {IArticle, IArticleInstance} from './article';
+
+const sequelizeInstance =
+    new Sequelize('articles', null, null, {
+        dialect: 'sqlite',
+        storage: './dist/db/db.sqlite',
+        port: 3306
+    });
+
+const article =
+    sequelizeInstance.define<IArticleInstance, IArticle>('Article', {
+        title: Sequelize.STRING,
+        description: Sequelize.STRING,
+        content: Sequelize.STRING
+    });
+
+/** ORM instance. */
+export const sequelize = sequelizeInstance;
+
+/** Article definition, used to query the database. */
+export const Article = article;

--- a/api/src/db/init.ts
+++ b/api/src/db/init.ts
@@ -1,0 +1,30 @@
+import {sequelize, Article} from './index';
+
+/** Create the database. */
+async function initDb() {
+
+    // Creates the file.
+    try {
+        await sequelize.authenticate();
+        console.log('Connection to the database successful.')
+    } catch (error) {
+        console.log(`Error while trying to connect to the database: ${error}`)
+    }
+
+    // Syncs the model
+    try {
+        await sequelize.sync({force: true});
+        console.log('Database sync sucessful');
+    } catch (error) {
+        console.log(`Error while trying to sync the model with the database : ${error}`);
+    }
+
+    // Inserts an article, to replace with fake data.
+    try {
+        await Article.create({title: 'Title', description: 'This is a test', content: 'bla bla bla'});
+    } catch (error) {
+        console.log(`Error while trying to insert an article in the database : ${error}`);
+    }
+}
+
+initDb();

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,11 +1,13 @@
 import express from 'express';
+import {Article} from './db/index';
 
 const app = express();
 
 app.get('/', (req, res) => {
-    res.send('Hello world !!!');
+    res.send('Hello world!');
 });
 
 app.listen(3000, () => {
-    console.log('Example app listening on port 3000!');
+    console.log('Lauching app on port 3000');
+    Article.find().then(article => console.log('Article in the database :', article.get()));
 });


### PR DESCRIPTION
This PR adds basic DB creation, schema and querying.

I chose to regroup all DB-related files into the `db/` folder under `src/` (and under `dist/` when compiled), including the DB file itself.

The `index.ts` file contains the DB connection object (`sequelize`) and the `Article` model object, which is used to interact with the `Article` table in the DB. `Article` hasn't been properly defined yet, it's just a temporary stub for testing the DB.

The `article.d.ts` file contains the necessary Typescript definitions for the `Article` model object.

The `init.ts` is the script that creates the database. There's a `npm run` script called `buildDb` that calls it (the compiled version of it).

`npm install` now also builds the application and the DB.