### PR TITLE
Test server init

### DIFF
--- a/api/gulpfile.js
+++ b/api/gulpfile.js
@@ -1,6 +1,7 @@
 const gulp = require('gulp');
 const ts = require('gulp-typescript');
 const babel = require('gulp-babel');
+const mocha = require('gulp-mocha');
 
 gulp.task('build', () => {
     const tsProject = ts.createProject('./tsconfig.json');

--- a/api/gulpfile.js
+++ b/api/gulpfile.js
@@ -1,7 +1,6 @@
 const gulp = require('gulp');
 const ts = require('gulp-typescript');
 const babel = require('gulp-babel');
-const mocha = require('gulp-mocha');
 
 gulp.task('build', () => {
     const tsProject = ts.createProject('./tsconfig.json');

--- a/api/package.json
+++ b/api/package.json
@@ -26,7 +26,6 @@
     "chai": "3.5.0",
     "gulp": "3.9.1",
     "gulp-babel": "6.1.2",
-    "gulp-mocha": "2.2.0",
     "gulp-typescript": "2.13.5",
     "mocha": "2.5.3",
     "ts-node": "0.7.3",

--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,7 @@
     "postinstall": "typings install && gulp build && node ./dist/db/init.js",
     "start": "node dist/index.js",
     "test": "mocha src/**/__tests__/**/*.ts",
-    "test:watch": "mocha src/**/__tests__/**/*.ts -w || 0",
+    "test:watch": "mocha src/**/__tests__/**/*.ts -w",
     "watch": "gulp watch"
   },
   "author": "KleeGroup",

--- a/api/package.json
+++ b/api/package.json
@@ -5,10 +5,11 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "gulp build",
-    "buildDb": "node ./dist/db/init.js",
+    "db:init": "node ./dist/db/init.js",
     "postinstall": "typings install && gulp build && node ./dist/db/init.js",
     "start": "node dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha src/**/__tests__/**/*.ts",
+    "test:watch": "mocha src/**/__tests__/**/*.ts -w || 0",
     "watch": "gulp watch"
   },
   "author": "KleeGroup",
@@ -22,9 +23,13 @@
   "devDependencies": {
     "babel-cli": "6.9.0",
     "babel-preset-node6": "11.0.0",
+    "chai": "3.5.0",
     "gulp": "3.9.1",
     "gulp-babel": "6.1.2",
+    "gulp-mocha": "2.2.0",
     "gulp-typescript": "2.13.5",
+    "mocha": "2.5.3",
+    "ts-node": "0.7.3",
     "typescript": "1.8.10",
     "typings": "1.0.4"
   }

--- a/api/src/db/__tests__/article-test.ts
+++ b/api/src/db/__tests__/article-test.ts
@@ -1,0 +1,13 @@
+import {Article} from '../index';
+import mochaAsync from '../../../test/mocha-async';
+
+describe('article', () => {
+    describe('article-load', () => {
+        it('should contains an article instance', mochaAsync(async () => {
+            const article = await Article.find();
+            chai.expect(article.get()).haveOwnPropertyDescriptor('title');
+            chai.expect(article.get()).haveOwnPropertyDescriptor('description');
+            chai.expect(article.get()).haveOwnPropertyDescriptor('content');
+        }));
+    });
+});

--- a/api/src/db/__tests__/init-test.ts
+++ b/api/src/db/__tests__/init-test.ts
@@ -1,0 +1,12 @@
+import {sequelize} from '../index';
+import mochaAsync from '../../../test/mocha-async';
+
+describe('db', () => {
+    it('should be able to connect', mochaAsync(async () => {
+        await sequelize.authenticate();
+    }));
+
+    it('should be able to sync', mochaAsync(async () => {
+        await sequelize.sync({force: false});
+    }));
+});

--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -5,7 +5,8 @@ const sequelizeInstance =
     new Sequelize('articles', null, null, {
         dialect: 'sqlite',
         storage: './dist/db/db.sqlite',
-        port: 3306
+        port: 3306,
+        logging: false
     });
 
 const article =

--- a/api/test/init.js
+++ b/api/test/init.js
@@ -1,0 +1,42 @@
+/*
+    This file contains the boilerplate required to launch mocha tests.
+    It sets up chai and a process that allows typescript + babel compilation on the fly to run the tests.
+ */
+
+'use strict';
+
+global.chai = require('chai');
+
+const babel = require('babel-core');
+
+const babelOpts = {
+    presets: [require('babel-preset-node6')],
+    ast: false
+};
+
+var tsLoader = require.extensions['.ts'];
+
+Object.defineProperty(require.extensions, '.ts', {
+    enumerable: true,
+    set: newTSLoader => tsLoader = newTSLoader,
+    get: () => loadPipeline
+});
+
+require('ts-node/register');
+
+function loadPipeline(m, filename) {
+    m._compile(compile(filename), filename);
+}
+
+function compile(filename) {
+    var tsOutput = mockLoad(tsLoader, filename);
+    var babelOutput = babel.transform(tsOutput, babelOpts);
+    return babelOutput.code;
+}
+
+function mockLoad(loader, filename) {
+    let content;
+    const module = {_compile: _content => content = _content};
+    loader(module, filename);
+    return content;
+}

--- a/api/test/mocha-async.ts
+++ b/api/test/mocha-async.ts
@@ -1,0 +1,11 @@
+/** Async helper function for mocha. */
+export default fn => {
+    return async (done) => {
+        try {
+            await fn();
+            done();
+        } catch (err) {
+            done(err);
+        }
+    };
+};

--- a/api/test/mocha.opts
+++ b/api/test/mocha.opts
@@ -1,0 +1,3 @@
+--require test/init.js
+--reporter spec
+--ui bdd

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -6,6 +6,8 @@
         "allowSyntheticDefaultImports": true
     },
     "exclude": [
-        "node_modules"
+        "node_modules",
+        "test",
+        "src/db/__tests__"
     ]
 }

--- a/api/typings.json
+++ b/api/typings.json
@@ -1,9 +1,13 @@
 {
     "globalDependencies": {
+        "chai": "registry:dt/chai#3.4.0+20160317120654",
+        "chai-as-promised": "registry:dt/chai-as-promised#0.0.0+20160423070304",
         "express": "registry:dt/express#4.0.0+20160317120654",
         "express-serve-static-core": "registry:dt/express-serve-static-core#0.0.0+20160322035842",
         "mime": "registry:dt/mime#0.0.0+20160316155526",
+        "mocha": "registry:dt/mocha#2.2.5+20160317120654",
         "node": "registry:dt/node#6.0.0+20160524002506",
+        "promises-a-plus": "registry:dt/promises-a-plus#0.0.0+20160317120654",
         "serve-static": "registry:dt/serve-static#0.0.0+20160501131543"
     },
     "dependencies": {

--- a/api/typings.json
+++ b/api/typings.json
@@ -1,13 +1,11 @@
 {
     "globalDependencies": {
         "chai": "registry:dt/chai#3.4.0+20160317120654",
-        "chai-as-promised": "registry:dt/chai-as-promised#0.0.0+20160423070304",
         "express": "registry:dt/express#4.0.0+20160317120654",
         "express-serve-static-core": "registry:dt/express-serve-static-core#0.0.0+20160322035842",
         "mime": "registry:dt/mime#0.0.0+20160316155526",
         "mocha": "registry:dt/mocha#2.2.5+20160317120654",
         "node": "registry:dt/node#6.0.0+20160524002506",
-        "promises-a-plus": "registry:dt/promises-a-plus#0.0.0+20160317120654",
         "serve-static": "registry:dt/serve-static#0.0.0+20160501131543"
     },
     "dependencies": {


### PR DESCRIPTION
This PR adds testing to the server app.

Tests must be written in Typescript (like the rest of the server app anyway) and are compiled on the fly when executing `npm test`.

Mocha tests can use async/await (because why the hell not), but to properly handle errors and the mocha `done()` callback, there's a wrapper function for it in the `test` folder.