### PR TITLE
Add markdown component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     },
     "globals": {
         "__dirname": false,
-        "process": false
+        "process": false,
+        "componentHandler": false
     },
     "parser": "babel-eslint",
     "extends": ["eslint:recommended", "plugin:react/recommended"],
@@ -45,6 +46,7 @@
         ],
         "react/prop-types": 0,
         "react/react-in-jsx-scope": 0,
+        "react/no-danger": 0,
         "semi": [
             "error",
             "always"

--- a/app/package.json
+++ b/app/package.json
@@ -67,7 +67,8 @@
     "react-redux": "4.4.5",
     "react-router": "2.4.1",
     "redux": "3.5.2",
-    "redux-thunk": "2.1.0"
+    "redux-thunk": "2.1.0",
+    "remarkable": "1.6.2"
   },
   "devDependencies": {
     "awesome-typescript-loader": "0.17.0",

--- a/app/src/back-office/index.jsx
+++ b/app/src/back-office/index.jsx
@@ -2,14 +2,14 @@ import ReactDOM from 'react-dom';
 import './index.scss';
 
 import {HelpCenterBase} from '../common/components/index';
-import {Router, browserHistory} from 'react-router';
+import {Router, hashHistory} from 'react-router';
 import routes from './routes';
 
 /** Root component of the back-office app. */
 function HelpCenter() {
     return (
         <HelpCenterBase>
-            <Router history={browserHistory} routes={routes}/>
+            <Router history={hashHistory} routes={routes}/>
         </HelpCenterBase>
     );
 }

--- a/app/src/back-office/index.scss
+++ b/app/src/back-office/index.scss
@@ -1,4 +1,5 @@
 body {
     background: #EEE;
     min-height: 0;
+    font-family: Roboto;
 }

--- a/app/src/common/components/article-edition/content-area.jsx
+++ b/app/src/common/components/article-edition/content-area.jsx
@@ -1,0 +1,49 @@
+import {Component, PropTypes} from 'react';
+import Markdown from 'remarkable';
+import i18n from 'i18next';
+
+export class ContentArea extends Component {
+    static propTypes = {
+        value: PropTypes.string,
+        onChange: PropTypes.func.isRequired
+    };
+
+    componentDidMount() {
+        componentHandler.upgradeDom();
+    }
+
+    state = {};
+    md = new Markdown();
+    handleChange = () => {
+        const value = this.refs.textarea.value;
+        this.setState({value});
+        this.props.onChange(value);
+    }
+    rawMarkup = () => ({__html: this.md.render(this.state.value)});
+
+    render() {
+        return (
+            <div className='content-area'>
+                <div className="mdl-textfield mdl-js-textfield content-area-textarea">
+                    <textarea
+                        ref='textarea'
+                        className="mdl-textfield__input"
+                        defaultValue={this.props.value}
+                        onChange={this.handleChange}
+                        id="textarea"
+                    />
+                    <label
+                        className="mdl-textfield__label"
+                        htmlFor="textarea"
+                    >
+                        {i18n.t('article-edit.content.placeholder')}
+                    </label>
+                </div>
+                <div
+                    className='content-area-display'
+                    dangerouslySetInnerHTML={this.rawMarkup()}
+                />
+            </div>
+        );
+    }
+}

--- a/app/src/common/i18n/en.ts
+++ b/app/src/common/i18n/en.ts
@@ -7,6 +7,11 @@ export const en = {
                 edit: 'edit'
             }
         },
+        'article-edit': {
+            content: {
+                placeholder: 'Type an article...'
+            }
+        },
 
         // Back office specific labels.
         'back-office': {

--- a/app/src/common/i18n/fr.ts
+++ b/app/src/common/i18n/fr.ts
@@ -7,6 +7,11 @@ export const fr = {
                 edit: 'éditer'
             }
         },
+        'article-edit': {
+            content: {
+                placeholder: 'Saississez un article...'
+            }
+        },
 
         // Back office specific labels.
         'back-office': {

--- a/app/src/common/style/edit.scss
+++ b/app/src/common/style/edit.scss
@@ -1,0 +1,63 @@
+.content-area {
+    display: flex;
+    margin: 10px;
+    height: calc(100% - 22px);
+
+    .content-area-textarea {
+        background: white;
+        flex: 1 1 auto;
+        width: 50%;
+        border-right: 1px solid #888;
+        padding: 10px;
+        height: 100%;
+
+        textarea {
+            font-family: Roboto;
+            height: 100%;
+            font-size: 14px;
+        }
+
+        label {
+            margin: -10px 10px 0;
+            width: calc(100% - 20px);
+            height: calc(100% - 3px);
+            font-size: 14px;
+        }
+    }
+
+    .content-area-display {
+        background: white;
+        flex: 1 1 auto;
+        width: 50%;
+        border-left: 1px solid #888;
+        overflow-y: scroll;
+        overflow-x: hidden;
+        padding: 10px;
+
+        blockquote {
+            padding: 10px 20px;
+            font-size: 18px;
+            border-left: 5px solid #eee;
+
+            p {
+                margin: 0;
+            }
+
+            &:before, &:after {
+               	display: none;
+            }
+        }
+
+        h1 {
+            font-size: 42px;
+        }
+
+        h2 {
+            font-size: 34px;
+        }
+
+        h3 {
+            font-size: 30px;
+        }
+    }
+}

--- a/app/src/common/style/index.ts
+++ b/app/src/common/style/index.ts
@@ -1,1 +1,2 @@
 import './list.scss';
+import './edit.scss';


### PR DESCRIPTION
This PR adds the markdown component to integrate to the edit page.

It works without any kind of configuration, which is pretty great, and since it's copypasted for a sample on the React homepage, it wasn't too hard.

I've done some basic styling, but not everything is up tight. We'll see later how it fares with real documents.