### PR TITLE
Add login service with tests

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -50,6 +50,8 @@
   "author": "KleeGroup",
   "license": "MIT",
   "dependencies": {
+    "body-parser": "1.15.1",
+    "cookie-session": "2.0.0-alpha.1",
     "express": "4.13.4",
     "lodash": "4.13.1",
     "sequelize": "3.23.3",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,14 +1,23 @@
 import express from 'express';
-import {articleService} from './services/article';
-import {swaggerService} from './swagger/index';
+import cookieSession from 'cookie-session';
+import bodyParser from 'body-parser';
 import path from 'path';
+
+import {articleService} from './services/article';
+import {signinService} from './services/signin';
+import {swaggerService} from './swagger/index';
+
 import {initDb} from './db/init-test-data';
 
 const app = express();
 app.use(express.static(path.resolve(process.cwd(), '../docs')));
+app.use(cookieSession({name: 'session', secret: 'secret'}));
+app.use(bodyParser.text());
+app.use(bodyParser.json());
 
 // Allow CORS.
 app.use((req, res, next) => {
+    res.header('Access-Control-Allow-Credentials', 'true');
     res.header('Access-Control-Allow-Origin', '*');
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
     next();
@@ -16,6 +25,7 @@ app.use((req, res, next) => {
 
 // Registers the services.
 articleService(app);
+signinService(app);
 swaggerService(app);
 
 app.listen(3000, () => {

--- a/api/src/services/__tests__/article-tests.ts
+++ b/api/src/services/__tests__/article-tests.ts
@@ -10,7 +10,7 @@ describe('Testing the services', () => {
         before(mochaAsync(async () => {
             const response = await fetch('http://localhost:3000/api/article/2');
             if (response.status >= 400) {
-                throw new Error("Bad response from server");
+                throw new Error('Bad response from server');
             }
             fetchDB = await response.json<IArticle>();
         }));
@@ -27,7 +27,7 @@ describe('Testing the services', () => {
         before(mochaAsync(async () => {
             const response = await fetch('http://localhost:3000/api/article');
             if (response.status >= 400) {
-                throw new Error("Bad response from server");
+                throw new Error('Bad response from server');
             }
             fetchDB = await response.json<IArticle>();
         }));

--- a/api/src/services/__tests__/login.ts
+++ b/api/src/services/__tests__/login.ts
@@ -1,0 +1,15 @@
+export async function login(password: string) {
+    return await fetch('http://localhost:3000/signin', {
+        method: 'POST',
+        body: password,
+        headers: {
+            'Content-Type': 'text/plain'
+        },
+    });
+}
+
+export async function loginAndGetCookie(password: string) {
+    return (await login(password)).headers.getAll('set-cookie')
+        .map(r => r.replace('; path=/; httponly', ''))
+        .join('; ');
+}

--- a/api/src/services/__tests__/signin-test.ts
+++ b/api/src/services/__tests__/signin-test.ts
@@ -1,0 +1,30 @@
+import fetch from 'isomorphic-fetch';
+import mochaAsync from '../../../test/mocha-async';
+import {login, loginAndGetCookie} from './login';
+
+describe('Session', () => {
+    it('should sign in and receive a cookie with correct password', mochaAsync(async () => {
+        const response = await login('password');
+        chai.expect(response.status).to.equal(200);
+        chai.expect(response.headers.getAll('set-cookie')).is.not.empty;
+        chai.expect(await response.text()).to.equal('Authentification successful');
+    }));
+
+    it('should be connected after login with correct password', mochaAsync(async () => {
+        const cookie = await loginAndGetCookie('password');
+        const response = await fetch('http://localhost:3000/signin', {headers: {cookie}});
+        chai.expect(await response.text()).to.equal('Connected');
+    }));
+
+    it('shouldn\'t sign in with incorrect password', mochaAsync(async () => {
+        const response = await login('yolo');
+        chai.expect(response.status).to.equal(403);
+        chai.expect(await response.text()).to.equal('Incorrect password');
+    }));
+
+    it('shouldn\'t be connected after login in with incorrect password', mochaAsync(async () => {
+        const cookie = await loginAndGetCookie('yolo');
+        const response = await fetch('http://localhost:3000/signin', {headers: {cookie}});
+        chai.expect(await response.text()).to.equal('Not connected');
+    }));
+});

--- a/api/src/services/signin.ts
+++ b/api/src/services/signin.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+
+export function signinService(app: express.Application) {
+
+    /** Sign in service. */
+    app.route('/signin')
+        .post((req, res) => {
+            if (req.body === 'password') {
+                req.session['signedIn'] = true;
+                res.status(200);
+                res.send('Authentification successful');
+            } else {
+                res.status(403);
+                req.session = null;
+                res.send('Incorrect password');
+            }
+        })
+        .get((req, res) => {
+            if (req.session['signedIn']) {
+                res.send('Connected');
+            } else {
+                res.send('Not connected');
+            }
+        });
+}

--- a/api/typings.json
+++ b/api/typings.json
@@ -1,6 +1,8 @@
 {
     "globalDependencies": {
+        "body-parser": "registry:dt/body-parser#0.0.0+20160317120654",
         "chai": "registry:dt/chai#3.4.0+20160317120654",
+        "cookie-session": "registry:dt/cookie-session#2.0.0-alpha.1+20160317120654",
         "express": "registry:dt/express#4.0.0+20160317120654",
         "express-serve-static-core": "registry:dt/express-serve-static-core#0.0.0+20160322035842",
         "faker": "registry:dt/faker#0.0.0+20160406111603",


### PR DESCRIPTION
This PR adds a signin service with a POST method that expects a password in its body (currently 'password') and a GET method which returns the connection status (right now it's a string, but it will probably change once we'll do something with it).

I used the `cookie-session` middleware that adds a `session` member to the `Request` object, that we can shape as we see fit. For now, it only has a `signedIn` boolean member.