### PR TITLE
Change typescript module resolution

### DIFF
--- a/api/src/db/__tests__/init-test.ts
+++ b/api/src/db/__tests__/init-test.ts
@@ -1,4 +1,4 @@
-import {sequelize} from '../index';
+import {sequelize} from '../';
 import mochaAsync from '../../../test/mocha-async';
 
 describe('db', () => {

--- a/api/src/db/init-test-data.ts
+++ b/api/src/db/init-test-data.ts
@@ -1,4 +1,4 @@
-import {sequelize, Article} from './index';
+import {sequelize, Article} from './';
 
 export const article1 = {id: 1, title: 'The First', description: 'The first description', content: 'Blablabla is the base' };
 export const article2 = {id: 2, title: 'The Second', description: 'The second description', content: 'Blablabla is the base : 2' };

--- a/api/src/db/init.ts
+++ b/api/src/db/init.ts
@@ -1,4 +1,4 @@
-import {sequelize, Article} from './index';
+import {sequelize, Article} from './';
 import {IArticle} from '../db/article';
 import faker from 'faker';
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import {articleService} from './services/article';
 import {signinService} from './services/signin';
-import {swaggerService} from './swagger/index';
+import {swaggerService} from './swagger';
 
 import {initDb} from './db/init-test-data';
 

--- a/api/src/services/article.ts
+++ b/api/src/services/article.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import {Article} from '../db/index';
+import {Article} from '../db';
 
 /**
  * @swagger

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "es2015",
+        "moduleResolution": "node",
         "target": "es2015",
         "outDir": "dist",
         "allowSyntheticDefaultImports": true

--- a/app/src/back-office/index.jsx
+++ b/app/src/back-office/index.jsx
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
-import './style/index';
+import './style';
 
-import {HelpCenterBase} from '../common/components/index';
+import {HelpCenterBase} from '../common/components';
 import {Router, hashHistory} from 'react-router';
 import routes from './routes';
 

--- a/app/src/back-office/routes.js
+++ b/app/src/back-office/routes.js
@@ -1,5 +1,5 @@
 import {HomeView} from './views/home';
-import {EditArticle} from './views/edit-article/index';
+import {EditArticle} from './views/edit-article';
 
 export default {
     path: '/',

--- a/app/src/back-office/views/edit-article/index.jsx
+++ b/app/src/back-office/views/edit-article/index.jsx
@@ -1,5 +1,5 @@
 import Layout from '../../layout';
-import {EditPage} from '../../../common/components/article-edition/index';
+import {EditPage} from '../../../common/components/article-edition';
 import {EditCartridgeContent} from '../../../common/components/article-edition/edit-cartridge-content';
 
 /** Root component of the back-office app. */

--- a/app/src/common/actions/__tests__/article-list-test.ts
+++ b/app/src/common/actions/__tests__/article-list-test.ts
@@ -1,5 +1,5 @@
 import {loadArticleList} from '../article-list';
-import {Action} from '../../actions/index';
+import {Action} from '../../actions';
 import {apiMockData} from '../../server/api-mock';
 
 describe('action: loadArticleList', () => {

--- a/app/src/common/actions/article-detail.ts
+++ b/app/src/common/actions/article-detail.ts
@@ -1,4 +1,4 @@
-import {Action} from './index';
+import {Action} from './';
 import {Article} from '../definitions/article';
 import {ArticleDetailAction} from '../definitions/article-detail';
 

--- a/app/src/common/actions/article-list.ts
+++ b/app/src/common/actions/article-list.ts
@@ -1,7 +1,7 @@
-import {Action} from './index';
+import {Action} from './';
 import {Article} from '../definitions/article';
 import {ArticleListAction} from '../definitions/article-list';
-import {Api} from '../server/index';
+import {Api} from '../server/';
 
 /** Action creator called on load request. */
 function requestArticleList(): ArticleListAction {
@@ -28,7 +28,7 @@ function failureArticleList(error: string): ArticleListAction {
 
 /** Loads the article list. Dispatches the request immediately and the result when it's loaded. */
 export function loadArticleList() {
-    return async (dispatch: Redux.Dispatch, getState, api: Api) => {
+    return async (dispatch, getState, api: Api) => {
         dispatch(requestArticleList());
         try {
             const articleList = await api.loadArticleList();

--- a/app/src/common/components/article-edition/__tests__/article-edition-tests.tsx
+++ b/app/src/common/components/article-edition/__tests__/article-edition-tests.tsx
@@ -1,4 +1,4 @@
-import {EditPage} from '../index';
+import {EditPage} from '../';
 import {shallow} from 'enzyme';
 
 describe('Edition Page', () => {

--- a/app/src/common/components/index.jsx
+++ b/app/src/common/components/index.jsx
@@ -1,12 +1,12 @@
 import 'babel-polyfill';
-import '../style/index';
+import '../style';
 import React from 'react';
 import 'material-design-lite/material';
 window.React = React;
 
 import {Provider} from 'react-redux';
-import {configureStore} from '../store/index';
-import {i18nInit} from '../i18n/index';
+import {configureStore} from '../store';
+import {i18nInit} from '../i18n';
 i18nInit();
 
 /** Root common component for both apps. Abstract away the connection to the store. */

--- a/app/src/common/definitions/article-detail.d.ts
+++ b/app/src/common/definitions/article-detail.d.ts
@@ -1,4 +1,4 @@
-import {Action} from '../actions/index';
+import {Action} from '../actions';
 import {Article} from './article';
 
 /** State spec for the `articleDetail` store node. */

--- a/app/src/common/definitions/article-list.d.ts
+++ b/app/src/common/definitions/article-list.d.ts
@@ -1,4 +1,4 @@
-import {Action} from '../actions/index';
+import {Action} from '../actions';
 import {Article} from './article';
 
 /** State spec for the `articleList` store node. */

--- a/app/src/common/reducers/__tests__/reducer-test.ts
+++ b/app/src/common/reducers/__tests__/reducer-test.ts
@@ -1,15 +1,15 @@
 import {defaultValue as articleList} from '../article-list';
 import {defaultValue as articleDetail} from '../article-detail';
-import {rootReducer} from '../index';
-import {Action} from '../../actions/index';
+import {rootReducer} from '../';
+import {Action} from '../../actions';
 import {omit} from 'lodash';
 
 describe('rootReducer', () => {
     const state = {articleList, articleDetail};
-
+    let newState: typeof state;
     describe('articleList', () => {
         describe('REQUEST_ARTICLE_LIST', () => {
-            const newState = rootReducer(state, {type: Action.REQUEST_ARTICLE_LIST});
+            newState = rootReducer(state, {type: Action.REQUEST_ARTICLE_LIST});
 
             it('shouldn\'t alter the remaining state nodes', () => {
                 chai.expect(omit(newState, 'articleList')).to.deep.equal(omit(state, 'articleList'));
@@ -20,7 +20,7 @@ describe('rootReducer', () => {
             });
         });
         describe('SUCCESS_ARTICLE_LIST', () => {
-            const newState = rootReducer(state, {type: Action.SUCCESS_ARTICLE_LIST, list: [{test: 'ok'}]});
+            newState = rootReducer(state, {type: Action.SUCCESS_ARTICLE_LIST, list: [{test: 'ok'}]});
 
             it('shouldn\'t alter the remaining state nodes', () => {
                 chai.expect(omit(newState, 'articleList')).to.deep.equal(omit(state, 'articleList'));
@@ -31,7 +31,7 @@ describe('rootReducer', () => {
             });
         });
         describe('FAILURE_ARTICLE_LIST', () => {
-            const newState = rootReducer(state, {type: Action.FAILURE_ARTICLE_LIST, error: 'error'});
+            newState = rootReducer(state, {type: Action.FAILURE_ARTICLE_LIST, error: 'error'});
 
             it('shouldn\'t alter the remaining state nodes', () => {
                 chai.expect(omit(newState, 'articleList')).to.deep.equal(omit(state, 'articleList'));

--- a/app/src/common/reducers/article-detail.ts
+++ b/app/src/common/reducers/article-detail.ts
@@ -1,4 +1,4 @@
-import {Action} from '../actions/index';
+import {Action} from '../actions';
 import {ArticleDetailAction, ArticleDetailState} from '../definitions/article-detail';
 
 export const defaultValue: ArticleDetailState = {isLoading: false};

--- a/app/src/common/reducers/article-list.ts
+++ b/app/src/common/reducers/article-list.ts
@@ -1,4 +1,4 @@
-import {Action} from '../actions/index';
+import {Action} from '../actions';
 import {ArticleListState, ArticleListAction} from '../definitions/article-list';
 
 export const defaultValue: ArticleListState = {isLoading: false, list: []};

--- a/app/src/common/reducers/index.ts
+++ b/app/src/common/reducers/index.ts
@@ -3,7 +3,7 @@ import {articleList} from './article-list';
 import {articleDetail} from './article-detail';
 
 /** The root reducer, fed to the store creator. */
-export const rootReducer = combineReducers({
+export const rootReducer = combineReducers<any>({
     articleDetail,
     articleList
 });

--- a/app/src/common/server/api-mock.ts
+++ b/app/src/common/server/api-mock.ts
@@ -1,4 +1,4 @@
-import {Api} from './index';
+import {Api} from './';
 
 /** Mock data for the api mock object. */
 export const apiMockData = {

--- a/app/src/common/store/index.ts
+++ b/app/src/common/store/index.ts
@@ -1,9 +1,9 @@
 import {createStore, applyMiddleware} from 'redux';
-import thunk from 'redux-thunk';
-import {rootReducer} from '../reducers/index';
+import * as thunk from 'redux-thunk';
+import {rootReducer} from '../reducers';
 import {api} from '../server/api';
 
 /** Creates the application store. */
 export function configureStore() {
-    return createStore(rootReducer, undefined, applyMiddleware(thunk['withExtraArgument'](api)));
+    return createStore(rootReducer, undefined, applyMiddleware(thunk.default['withExtraArgument'](api)));
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "es2015",
+        "moduleResolution": "node",
         "target": "es2015",
         "outDir": "dist",
         "allowJs": true,

--- a/app/typings.json
+++ b/app/typings.json
@@ -4,6 +4,7 @@
         "lodash": "registry:npm/lodash#4.0.0+20160416211519",
         "react-redux": "registry:npm/react-redux#4.4.0+20160207114942",
         "react-router": "registry:npm/react-router#2.0.0+20160214194820",
+        "redux-thunk": "registry:npm/redux-thunk#2.0.0+20160525185520",
         "webpack": "registry:npm/webpack#1.12.9+20160418172948"
     },
     "globalDependencies": {
@@ -24,8 +25,6 @@
         "react-addons-update": "registry:dt/react-addons-update#0.14.0+20160316155526",
         "react-dom": "registry:dt/react-dom#0.14.0+20160412154040",
         "react-global": "registry:dt/react-global#0.14.0+20160316155526",
-        "redux": "registry:dt/redux#3.3.1+20160326112656",
-        "redux-thunk": "registry:dt/redux-thunk#2.0.1+20160317120654",
         "sinon": "registry:dt/sinon#1.16.0+20160517064723",
         "sinon-chai": "registry:dt/sinon-chai#2.7.0+20160317120654"
     }


### PR DESCRIPTION
I just found out that Typescript had a `moduleResolution` flag (i should have known) and that it had the wrong default value. We don't need all those `/index`es anymore, and we can directly consume Redux typings from npm, so there's a few other things that changed.