### PR TITLE
Add security to edit page

### DIFF
--- a/api/src/services/__tests__/article-tests.ts
+++ b/api/src/services/__tests__/article-tests.ts
@@ -47,6 +47,11 @@ describe('Article', () => {
     });
 
     describe('POST /article', () => {
+        it('should return an error when not connected', mochaAsync(async () => {
+            const response = await(await fetch('http://localhost:3000/api/article', {method: 'POST', body: JSON.stringify(article1)})).json();
+            chai.expect(response).to.deep.equal({error: 'Cannot save an article when not connected'});
+        }));
+
         it('Should create a new article', mochaAsync(async () => {
             const article = {
                 title: 'Hello',
@@ -54,11 +59,13 @@ describe('Article', () => {
                 content: 'Hey, the content will be there, you know ?',
                 published: false
             };
+            const cookie = await loginAndGetCookie('password');
             const response = await fetch('http://localhost:3000/api/article', {
                 method: 'POST',
                 body: JSON.stringify(article),
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    cookie
                 }
             });
             chai.expect(await response.json()).to.deep.equal({success: true});

--- a/app/src/back-office/index.jsx
+++ b/app/src/back-office/index.jsx
@@ -9,7 +9,7 @@ import routes from './routes';
 function HelpCenter() {
     return (
         <HelpCenterBase>
-            <Router history={hashHistory} routes={routes}/>
+            <Router history={hashHistory} routes={routes} />
         </HelpCenterBase>
     );
 }

--- a/app/src/back-office/views/edit-article/index.jsx
+++ b/app/src/back-office/views/edit-article/index.jsx
@@ -3,7 +3,7 @@ import {EditPage} from '../../../common/components/article-edition';
 import {EditCartridgeContent} from '../../../common/components/article-edition/edit-cartridge-content';
 import {TitleComponent} from '../home/title-component';
 
-/** Root component of the back-office app. */
+/** Edition page. */
 export function EditArticle() {
     return (
         <Layout Content={<EditCartridgeContent />} BarMiddle={<TitleComponent />}>

--- a/app/src/common/components/article-edition/edit-cartridge-content.tsx
+++ b/app/src/common/components/article-edition/edit-cartridge-content.tsx
@@ -4,7 +4,10 @@ import {connect} from 'react-redux';
 import {updateArticle, saveArticle} from '../../actions/article-detail';
 
 @connect(
-    state => ({article: state.articleDetail.article}),
+    state => ({
+        article: state.articleDetail.article,
+        connected: state.login.isConnected
+    }),
     dispatch => (
         {
             updateArticle: (attribute, value) => dispatch(updateArticle(attribute, value)),
@@ -107,6 +110,10 @@ export class EditCartridgeContent extends Component<any, any> {
     };
 
     render() {
+        if (!this.props.connected) {
+            return <div />;
+        }
+
         return (
             <div>
                 {this.renderTitleZone() }

--- a/app/src/common/components/article-edition/index.tsx
+++ b/app/src/common/components/article-edition/index.tsx
@@ -1,4 +1,3 @@
-// IMPORTS
 import {connect} from 'react-redux';
 import {Component, PropTypes} from 'react';
 import {ContentArea} from './content-area';
@@ -6,13 +5,15 @@ import i18n from 'i18next';
 import {updateArticle, saveArticle, loadArticleDetail} from '../../actions/article-detail';
 
 @connect(
-    state => ({article: state.articleDetail.article}),
-    dispatch => (
-        {
-            updateArticle: (attribute, value) => dispatch(updateArticle(attribute, value)),
-            saveArticle: article => dispatch(saveArticle(article)),
-            loadArticleDetail: article => dispatch(loadArticleDetail(article))
-        })
+    state => ({
+        article: state.articleDetail.article,
+        connected: state.login.isConnected
+    }),
+    dispatch => ({
+        updateArticle: (attribute, value) => dispatch(updateArticle(attribute, value)),
+        saveArticle: article => dispatch(saveArticle(article)),
+        loadArticleDetail: article => dispatch(loadArticleDetail(article))
+    })
 )
 export class EditPage extends Component<any, any> {
 
@@ -48,6 +49,10 @@ export class EditPage extends Component<any, any> {
     }
 
     render() {
+        if (!this.props.connected) {
+            return <div />;
+        }
+
         const {isVisible} = this.state;
         return (
             <div className='edit-page-container'>

--- a/app/src/common/server/api.ts
+++ b/app/src/common/server/api.ts
@@ -40,6 +40,7 @@ export const api: Api = {
         const response = await fetch('http://localhost:3000/api/article', {
             method: 'POST',
             body: JSON.stringify(article),
+            credentials: 'include',
             headers: {
                 'Content-Type': 'application/json'
             }


### PR DESCRIPTION
This PR adds security to the edit page.

You can't save an article if you're not connected, and the edit page displays nothing in that case.

I also updated the swagger definitions and added the one for POST.