### PR TITLE
Adds auto-save and edition buttons for markdown.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -79,6 +79,7 @@
     "react-dom": "15.1.0",
     "react-redux": "4.4.5",
     "react-router": "2.4.1",
+    "react-simple-markdown-editor": "1.1.0",
     "react-tap-event-plugin": "1.0.0",
     "redux": "3.5.2",
     "redux-thunk": "2.1.0",

--- a/app/src/common/actions/__tests__/article-detail-tests.ts
+++ b/app/src/common/actions/__tests__/article-detail-tests.ts
@@ -40,7 +40,6 @@ describe('Article Detail Actions', () => {
     describe('updateArticle', () => {
         it('should dispatch request then receive actions', done => {
             chai.expect(updateArticle('title', 'title', () => null)).with.state({articleDetail}).to.dispatch.actions([
-                {type: Action.REQUEST_ACTION_ARTICLE},
                 {
                     type: Action.UPDATE_ARTICLE,
                     attribute: 'title',

--- a/app/src/common/actions/article-detail.ts
+++ b/app/src/common/actions/article-detail.ts
@@ -102,7 +102,6 @@ function updateArticleAttribute(attribute: string, value: string | boolean): Art
 /** Updates an attribute of the article in the store and saves it on the server. */
 export function updateArticle(attribute: string, value: string | boolean, successHandler: () => void): any {
     return async (dispatch, getState, api: Api) => {
-        dispatch(requestActionArticle());
         dispatch(updateArticleAttribute(attribute, value));
         try {
             const response = await api.saveArticle(Object.assign({}, getState().articleDetail.article, {[attribute]: value}));

--- a/app/src/common/components/article-edition/content-area.tsx
+++ b/app/src/common/components/article-edition/content-area.tsx
@@ -4,11 +4,11 @@ import i18n from 'i18next';
 import {connect} from 'react-redux';
 import {updateArticle} from '../../actions/article-detail';
 import {withRouter} from 'react-router';
-import {RaisedButton, TextField, LinearProgress} from 'material-ui';
-import {State} from '../../store/default-state';
+import {RaisedButton, LinearProgress} from 'material-ui';
+import {SimpleMarkdownEditor} from 'react-simple-markdown-editor';
 
 @connect(
-    (state: State) => ({
+    (state) => ({
         content: state.articleDetail.article.content,
         connected: state.login.isConnected,
         loading: state.articleDetail.isLoading,
@@ -22,17 +22,8 @@ class ContentArea extends Component<any, any> {
     md = new Markdown({linkTarget: '_blank'});
     timer: number;
 
-    getRowNumber = () => {
-        const textField = this.refs['content-area-textarea'] as Element;
-        if (textField) {
-            return Math.round(textField.clientHeight / 25) - 2;
-        } else {
-            return 10;
-        }
-    }
-
     handleChange = () => {
-        const content = this.refs['textarea']['getValue']();
+        const content = this.refs['textarea']['value'];
         this.setState({content});
         clearTimeout(this.timer);
         this.timer = setTimeout(this.save, 5000);
@@ -61,8 +52,27 @@ class ContentArea extends Component<any, any> {
             <div className='content'>
                 <div className='header'>
                     <div className='edit'>
+                        <div className='buttons' onClick={this.handleChange}>
+                            <SimpleMarkdownEditor
+                                textAreaID='textarea'
+                                enabledButtons={{code: false}}
+                                styles={{button: {width: '40px', height: '40px', fontFamily: 'Roboto', background: 'none'}}}
+                                buttonHtmlText={{
+                                    bold: '<i class="material-icons">format_bold</i>',
+                                    italic: '<i class="material-icons">format_italic</i>',
+                                    strike: '<i class="material-icons">strikethrough_s</i>',
+                                    quote: '<i class="material-icons">format_quote</i>',
+                                    h1: '<i class="material-icons">title</i><i>1</i>',
+                                    h2: '<i class="material-icons">title</i><i>2</i>',
+                                    h3: '<i class="material-icons">title</i><i>3</i>',
+                                    bullet: '<i class="material-icons">format_list_bulleted</i>',
+                                    link: '<i class="material-icons">insert_link</i>',
+                                    image: '<i class="material-icons">insert_photo</i>'
+                                }}
+                            />
+                        </div>
                         {this.props.loading ?
-                            <LinearProgress style={{marginTop: '18px', height: '2px'}} />
+                            <LinearProgress style={{marginTop: '18px', height: '2px', width: '150px', float: 'right'}} />
                         : this.props.error ?
                             <div className='error save-text'><i className='material-icons'>error</i><div>{this.props.error}</div></div>
                         : this.state.content !== this.props.content ?
@@ -80,16 +90,12 @@ class ContentArea extends Component<any, any> {
                     </div>
                 </div>
                 <div className='workspace'>
-                    <div className='textarea' ref='content-area-textarea'>
-                        <TextField
+                    <div className='textarea'>
+                        <textarea
                             ref='textarea'
-                            multiLine={true}
-                            fullWidth={true}
-                            hintText={i18n.t('article-edit.content.placeholder')}
+                            id='textarea'
                             value={this.state.content}
                             onChange={this.handleChange}
-                            rowsMax={this.getRowNumber()}
-                            rows={this.getRowNumber()}
                         />
                     </div>
                     <div

--- a/app/src/common/components/article-edition/content-area.tsx
+++ b/app/src/common/components/article-edition/content-area.tsx
@@ -32,7 +32,9 @@ class ContentArea extends Component<any, any> {
     rawMarkup = () => ({__html: this.md.render(this.state.content)});
     save = () => {
         clearTimeout(this.timer);
-        this.props.updateArticle(this.state.content, () => this.props.router.push(''));
+        if (this.props.content !== this.state.content) {
+            this.props.updateArticle(this.state.content, () => this.props.router.push(''));
+        }
     };
 
     componentWillMount() {

--- a/app/src/common/components/article-edition/lib.d.ts
+++ b/app/src/common/components/article-edition/lib.d.ts
@@ -1,0 +1,8 @@
+declare module 'remarkable' {
+    const r: any;
+    export = r;
+}
+
+declare module 'react-simple-markdown-editor' {
+    export class SimpleMarkdownEditor extends React.Component<any, any> {}
+}

--- a/app/src/common/components/article-edition/remarkable.d.ts
+++ b/app/src/common/components/article-edition/remarkable.d.ts
@@ -1,4 +1,0 @@
-declare module 'remarkable' {
-    const r: any;
-    export = r;
-}

--- a/app/src/common/i18n/en.ts
+++ b/app/src/common/i18n/en.ts
@@ -45,6 +45,7 @@ export const en = {
                 toPublish: 'to publish',
                 publish: 'publish',
                 unpublish: 'unpublish',
+                upToDate: 'Content up to date.',
                 popup: {
                     confirmMessage: 'Do you to delete this article ?',
                     confirm: 'yes',

--- a/app/src/common/i18n/fr.ts
+++ b/app/src/common/i18n/fr.ts
@@ -45,6 +45,7 @@ export const fr = {
                 toPublish: 'à publier',
                 publish: 'publier',
                 unpublish: 'dépublier',
+                upToDate: 'Contenu à jour.',
                 popup: {
                     confirmMessage: 'Voulez-vous vraiment supprimer cet article ?',
                     confirm: 'oui',

--- a/app/src/common/reducers/__tests__/reducer-test.ts
+++ b/app/src/common/reducers/__tests__/reducer-test.ts
@@ -62,7 +62,7 @@ describe('rootReducer', () => {
         describe('UPDATE_ARTICLE', () => {
             const newState = rootReducer(defaultState, {type: Action.UPDATE_ARTICLE, attribute: 'title', value: 'TITLE'});
             it('should correctly set the state with a ERROR_ACTION_ARTICLE action', () => {
-                chai.expect(newState.articleDetail.isLoading).to.equal(false);
+                chai.expect(newState.articleDetail.isLoading).to.equal(true);
                 chai.expect(newState.articleDetail.article.title).to.equal('TITLE');
                 chai.expect(newState.articleDetail.article.description).to.equal(defaultState.articleDetail.article.description);
                 chai.expect(newState.articleDetail.article.content).to.equal(defaultState.articleDetail.article.content);

--- a/app/src/common/reducers/article-detail.ts
+++ b/app/src/common/reducers/article-detail.ts
@@ -37,7 +37,7 @@ export function articleDetail(state = defaultValue, action: ArticleDetailAction)
         case Action.UPDATE_ARTICLE:
             return a({}, state, {
                 article: a({}, state.article, {[action.attribute]: action.value}),
-                isLoading: false
+                isLoading: true
             });
         case Action.CLEAR_ARTICLE:
             return defaultValue;

--- a/app/src/common/style/common.scss
+++ b/app/src/common/style/common.scss
@@ -8,7 +8,6 @@ input:-webkit-autofill {
     align-items: center;
     justify-content: center;
     font-weight: bold;
-    color: indianred;
 
     > .material-icons {
         font-size: 32px;

--- a/app/src/common/style/edit.scss
+++ b/app/src/common/style/edit.scss
@@ -186,6 +186,17 @@
                 > .save-button {
                     float: right;
                 }
+
+                > .save-text {
+                    float: right;
+                    color: #CCC;
+                    padding: 8px;
+                }
+
+                > .error {
+                    color: #F44336;
+                    padding: 3px;
+                }
             }
 
             > .preview {

--- a/app/src/common/style/edit.scss
+++ b/app/src/common/style/edit.scss
@@ -197,6 +197,28 @@
                     color: #F44336;
                     padding: 3px;
                 }
+
+                > .buttons > div > div {
+                    .material-icons {
+                        margin-top: 8px;
+                    }
+
+                    i:not(.material-icons) {
+                        position: relative;
+                        left: -4px;
+                        font-style: normal;
+                    }
+
+                    i {
+                        transition: color 0.1s ease-out;
+                    }
+
+                    &:hover {
+                        i {
+                            color: lighten(rgb(0, 121, 107), 10%)
+                        }
+                    }
+                }
             }
 
             > .preview {
@@ -227,8 +249,13 @@
                 display: flex;
                 overflow: hidden;
 
-                hr[style] {
-                    bottom: -22px!important;
+                textarea {
+                    width: 100%;
+                    font-family: Roboto;
+                    font-size: 16px;
+                    resize: none;
+                    border: none;
+                    outline: none;
                 }
             }
 


### PR DESCRIPTION
I used a simple library to make the buttons (`react-simple-markdown-editor`). It wasn't working with the `material-ui` textarea so it was the best occasion to get rid of it (it came with other problems).

The content auto-saves 5 seconds after the last modification. It's the same action as a regular save, so it displays a snackbar event. The save button is disabled if there is nothing to save and during saving.