### PR TITLE
Opens the app for extension

### DIFF
--- a/api/gulpfile.js
+++ b/api/gulpfile.js
@@ -1,13 +1,19 @@
 const gulp = require('gulp');
 const ts = require('gulp-typescript');
 const babel = require('gulp-babel');
+const merge = require('merge2');
+const clip = require('gulp-clip-empty-files');
 
 gulp.task('build', () => {
     const tsProject = ts.createProject('./tsconfig.json');
-    return gulp.src(["src/**/*.ts", "typings/**/*.ts", "!src/**/__tests__/**"])
-        .pipe(ts(tsProject))
-        .pipe(babel())
-        .pipe(gulp.dest('./dist'));
+    const tsResult = gulp.src(['src/**/*.ts', 'src/**/*.d.ts', 'typings/**/*.ts', '!src/**/__tests__/**'])
+        .pipe(ts(tsProject));
+    return merge([
+        tsResult.dts,
+        tsResult.js.pipe(babel())
+    ])
+    .pipe(clip())
+    .pipe(gulp.dest('./dist'));
 });
 
 gulp.task('watch', ['build'], () => gulp.watch('src/**/*.ts', ['build']));

--- a/api/package.json
+++ b/api/package.json
@@ -7,6 +7,7 @@
     "build": "gulp build",
     "build:watch": "gulp watch",
     "db-init": "better-npm-run db-init",
+    "db-init:prod": "better-npm-run db-init-prod",
     "start": "better-npm-run start",
     "start:watch": "better-npm-run start-watch",
     "start:test": "better-npm-run start-test",
@@ -20,29 +21,35 @@
     "db-init": {
       "command": "cd dist && node ./db/init.js",
       "env": {
-        "DB_ENV": "production"
+        "DB_ENV": "dev"
+      }
+    },
+    "db-init-prod": {
+      "command": "cd dist && node ./db/init.js",
+      "env": {
+        "DB_ENV": "prod"
       }
     },
     "start": {
-      "command": "cd dist && node index.js",
+      "command": "cd dist && node default.js",
       "env": {
-        "DB_ENV": "production"
+        "DB_ENV": "dev"
       }
     },
     "start-watch": {
-      "command": "cd dist && nodemon index.js",
+      "command": "cd dist && nodemon default.js",
       "env": {
-        "DB_ENV": "production"
+        "DB_ENV": "dev"
       }
     },
     "start-test": {
-      "command": "cd dist && node index.js",
+      "command": "cd dist && node default.js",
       "env": {
         "DB_ENV": "test"
       }
     },
     "start-watch-test": {
-      "command": "cd dist && nodemon index.js",
+      "command": "cd dist && nodemon default.js",
       "env": {
         "DB_ENV": "test"
       }
@@ -68,8 +75,10 @@
     "faker": "3.1.0",
     "gulp": "3.9.1",
     "gulp-babel": "6.1.2",
+    "gulp-clip-empty-files": "0.1.2",
     "gulp-typescript": "2.13.6",
     "isomorphic-fetch": "2.2.1",
+    "merge2": "1.0.2",
     "mocha": "2.5.3",
     "nodemon": "1.9.2",
     "ts-node": "0.9.3",

--- a/api/src/db/article.ts
+++ b/api/src/db/article.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 
 /** Represents an article. */
-interface IArticle {
+export interface IArticle {
     id?: number;
     title: string;
     description: string;
@@ -13,4 +13,4 @@ interface IArticle {
 }
 
 /** Represents the article instance for the ORM (ie the object returned by queries) */
-interface IArticleInstance extends Sequelize.Instance<{}, IArticle> { }
+export interface IArticleInstance extends Sequelize.Instance<{}, IArticle> { }

--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -1,11 +1,11 @@
 import Sequelize from 'sequelize';
 import {IArticle, IArticleInstance} from './article';
-import path from 'path';
+import {join} from 'path';
 
 const sequelizeInstance =
     new Sequelize('articles', null, null, {
         dialect: 'sqlite',
-        storage: process.env.IS_BUNDLE ? './db/db.sqlite' : process.env.DB_ENV === 'production' ? path.join(__dirname, '../../dist/db/db.sqlite') : ':memory:',
+        storage: process.env.DB_ENV !== 'test' ? join(__dirname, './db.sqlite') : ':memory:',
         port: 3306,
         logging: false
     });

--- a/api/src/db/init.ts
+++ b/api/src/db/init.ts
@@ -21,22 +21,24 @@ async function initDb() {
         console.log(`Error while trying to sync the model with the database : ${error}`);
     }
 
-    // Populate the database with fake data
-    try {
-        let data: IArticle[] = [];
-        for (let i = 0; i < 10; i++) {
-            data.push({
-                title: faker.commerce.department(),
-                description: faker.lorem.sentence(),
-                content: faker.lorem.sentences(),
-                published: faker.random.boolean(),
-                publishedAt: new Date().toISOString()
-            });
+    if (process.env.DB_ENV !== 'prod') {
+        // Populate the database with fake data
+        try {
+            let data: IArticle[] = [];
+            for (let i = 0; i < 10; i++) {
+                data.push({
+                    title: faker.commerce.department(),
+                    description: faker.lorem.sentence(),
+                    content: faker.lorem.sentences(),
+                    published: faker.random.boolean(),
+                    publishedAt: new Date().toISOString()
+                });
+            }
+            await Article.bulkCreate(data);
+            console.log('10 articles successfully inserted.');
+        } catch (error) {
+            console.log(`Error while trying to insert an article in the database : ${error}`);
         }
-        await Article.bulkCreate(data);
-        console.log('10 articles successfully inserted.');
-    } catch (error) {
-        console.log(`Error while trying to insert an article in the database : ${error}`);
     }
 }
 

--- a/api/src/default.ts
+++ b/api/src/default.ts
@@ -1,0 +1,23 @@
+import app from './';
+import {initDb} from './db/init-test-data';
+import expressJwt from 'express-jwt';
+
+import {articleService} from './services/article';
+import {signinService} from './services/signin';
+import {swaggerService} from './swagger/index';
+
+app.use(expressJwt({secret: 'secret', credentialsRequired: false}));
+
+// When testing, we recreate the db for each request.
+if (process.env.DB_ENV === 'test') {
+    app.use(async (req, res, next) => {
+        await initDb();
+        next();
+    });
+}
+
+articleService(app);
+signinService(app);
+swaggerService(app);
+
+app.listen(1337, () => console.log('Launching app on port 1337.'));

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,17 +1,9 @@
-import express from 'express';
-import expressJwt from 'express-jwt';
+import express, {Express} from 'express';
 import bodyParser from 'body-parser';
 import path from 'path';
 
-import {articleService} from './services/article';
-import {signinService} from './services/signin';
-import {swaggerService} from './swagger/index';
-
-import {initDb} from './db/init-test-data';
-
-const app = express();
+const app: Express = express();
 app.use(express.static(path.resolve(process.cwd(), process.env.IS_BUNDLE ? './app' : './docs')));
-app.use(expressJwt({secret: 'secret', credentialsRequired: false}));
 app.use(bodyParser.text());
 app.use(bodyParser.json());
 
@@ -23,19 +15,4 @@ app.use((req, res, next) => {
     next();
 });
 
-// When testing, we recreate the db for each request.
-if (process.env.DB_ENV === 'test') {
-    app.use(async (req, res, next) => {
-        await initDb();
-        next();
-    });
-}
-
-// Registers the services.
-articleService(app);
-signinService(app);
-swaggerService(app);
-
-app.listen(1337, () => {
-    console.log('Lauching app on port 1337');
-});
+export default app;

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -4,7 +4,8 @@
         "moduleResolution": "node",
         "target": "es2015",
         "outDir": "dist",
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "declaration": true
     },
     "exclude": [
         "node_modules"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "0.1.0",
   "description": "Focus help center",
   "author": "KleeGroup",
+  "main": "./dist/index.js",
   "license": "MIT",
+  "scripts": {
+    "postinstall": "sh packaging.sh",
+    "start": "cd dist && node default.js"
+  },
   "devDependencies": {
     "babel-eslint": "6.1.0",
     "envify": "3.4.1",

--- a/packaging.sh
+++ b/packaging.sh
@@ -1,21 +1,21 @@
 cd api
 npm run build
+npm run db-init:prod
 cd ../app
 npm run build
 cd ..
-mkdir -p dist/app
+mkdir -p dist/app dist/typings
 cp api/dist/. dist/ -R
+cp api/typings/. dist/typings -R
 cp app/dist/. dist/app -R
 cp api/package.json dist/package.json
+cp api/tsconfig.json dist/tsconfig.json
 cd dist
 npm install --only=prod
 cd ..
 rm dist/package.json
 export IS_BUNDLE=true
 "./node_modules/.bin/envify" dist/index.js > dist/index2.js
-"./node_modules/.bin/envify" dist/db/index.js > dist/db/index2.js
 rm dist/index.js
-rm dist/db/index.js
 mv dist/index2.js dist/index.js
-mv dist/db/index2.js dist/db/index.js
 unset IS_BUNDLE


### PR DESCRIPTION
The `index.ts` entry point now exports the `app` object for further middleware additions (authentification mostly) and there's a new `default.ts` file that reintroduces what the former `index.ts` did.

Most notably, the app doesn't include any service by default because the consumer is expected to provide its own login service and to put additional middlewares before any service.

Since the app is now supposed to be consumed instead of simply packaged and deployed, I included all typescript definitions among the built files.

The database can now be initialized without any data.

Running `npm run postinstall` in the root folder will package everything in the `dist` folder and `npm start` will start the default application. `npm install` doesn't do anything yet and you are still supposed manually run npm install in both folders before. To use it to create a new app, you just have to copy the dist folder and import stuff from there just as if it were a module.

I should be able to do better though, given more time.