### PR TITLE
Fix packaging

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -3,7 +3,7 @@ import bodyParser from 'body-parser';
 import path from 'path';
 
 const app: Express = express();
-app.use(express.static(path.resolve(process.cwd(), process.env.IS_BUNDLE ? './app' : './docs')));
+app.use(express.static(path.resolve(__dirname, process.env.IS_BUNDLE ? './app' : './docs')));
 app.use(bodyParser.text());
 app.use(bodyParser.json());
 

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
       "command": "webpack --config ./webpack.back.js && webpack --config ./webpack.ext.js",
       "env": {
         "BABEL_ENV": "production",
+        "NODE_ENV": "production",
         "LANG": "fr"
       }
     },

--- a/app/src/common/server/api.ts
+++ b/app/src/common/server/api.ts
@@ -2,6 +2,9 @@ import fetch from 'isomorphic-fetch';
 import {Article} from '../definitions/article';
 import {Api} from './index';
 
+declare const process: any;
+const apiRoot = process.env.IS_BUNDLE === 'true' ? '.' : 'http://localhost:1337';
+
 async function fetchWithLogin(url: string, options?) {
     try {
         const token = localStorage.getItem('token');
@@ -18,12 +21,12 @@ async function fetchWithLogin(url: string, options?) {
 /** Api object to call the server. */
 export const api: Api = {
     async loadArticleList(filter?: string) {
-        const response = await fetchWithLogin(`http://localhost:1337/api/article${filter ? `?filter=${filter}` : ''}`);
+        const response = await fetchWithLogin(`${apiRoot}/api/article${filter ? `?filter=${filter}` : ''}`);
         return response.json<Article[]>();
     },
 
     async login(password) {
-        const response = await fetchWithLogin('http://localhost:1337/signin', {
+        const response = await fetchWithLogin(`${apiRoot}/signin`, {
             method: 'POST',
             body: password
         });
@@ -38,13 +41,13 @@ export const api: Api = {
     },
 
     async isConnected() {
-        const response = await fetchWithLogin('http://localhost:1337/signin');
+        const response = await fetchWithLogin(`${apiRoot}/signin`);
         const data = await response.json<{success: boolean}>();
         return !!data.success;
     },
 
     async saveArticle(article) {
-        const response = await fetchWithLogin('http://localhost:1337/api/article', {
+        const response = await fetchWithLogin(`${apiRoot}/api/article`, {
             method: 'POST',
             body: JSON.stringify(article),
             headers: {
@@ -60,7 +63,7 @@ export const api: Api = {
     },
 
     async deleteArticle(id) {
-        const response = await fetchWithLogin(`http://localhost:1337/api/article/${id}`, {method: 'DELETE'});
+        const response = await fetchWithLogin(`${apiRoot}/api/article/${id}`, {method: 'DELETE'});
         const data = await response.json<{success: boolean, error: string}>();
         if (data.success) {
             return true;
@@ -70,7 +73,7 @@ export const api: Api = {
     },
 
     async getArticle(id) {
-        const response = await fetchWithLogin(`http://localhost:1337/api/article/${id}`, {method: 'GET'});
+        const response = await fetchWithLogin(`${apiRoot}/api/article/${id}`, {method: 'GET'});
         const data = await response.json<Article | {error: string}>();
         if ((data as Article).title) {
             return data;

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -20,7 +20,8 @@ module.exports = (app, isDev) => ({
             'process.env.ENV': `"${process.env.ENV}"`,
             'process.env.ROOT_BACK_URL': `"${process.env.ROOT_BACK_URL}"`,
             'process.env.ROOT_EXTENSION_URL': `"${process.env.ROOT_EXTENSION_URL}"`,
-            'process.env.ROOT_APP_URL': `"${process.env.ROOT_APP_URL}"`
+            'process.env.ROOT_APP_URL': `"${process.env.ROOT_APP_URL}"`,
+            'process.env.IS_BUNDLE': `"${process.env.IS_BUNDLE}"`
         })
     ].concat(isDev ? [
         new webpack.HotModuleReplacementPlugin()

--- a/packaging.sh
+++ b/packaging.sh
@@ -1,3 +1,4 @@
+export IS_BUNDLE=true
 cd api
 npm run build
 npm run db-init:prod
@@ -14,7 +15,6 @@ cd dist
 npm install --only=prod
 cd ..
 rm dist/package.json
-export IS_BUNDLE=true
 "./node_modules/.bin/envify" dist/index.js > dist/index2.js
 rm dist/index.js
 mv dist/index2.js dist/index.js


### PR DESCRIPTION
Small fixes.
Works better now.

In particular, there's now a `apiRoot` param for calling the server on the `api` object on the client, which is set to `.` in bundle so as the consumer an use whatever port he wants.