### PR TITLE
Remove delete verbe from routes

### DIFF
--- a/api/src/services/article.ts
+++ b/api/src/services/article.ts
@@ -342,8 +342,8 @@ export function articleService(prefix: string, app: express.Application) {
 
     /**
      * @swagger
-     * /api/article/{id}:
-     *   delete:
+     * /api/article/{id}/delete:
+     *   post:
      *     tags:
      *       - Article
      *     description: Deletes an article.
@@ -369,7 +369,7 @@ export function articleService(prefix: string, app: express.Application) {
      *         schema:
      *           $ref: '#/definitions/Error'
      */
-    app.delete(`${prefix}/api/article/:id`, async (req, res) => {
+    app.post(`${prefix}/api/article/:id/delete`, async (req, res) => {
         if (!(req.user && req.user.signedIn)) {
             res.status(403);
             res.json({ error: 'Cannot delete an article when not connected' });

--- a/app/src/common/server/api.ts
+++ b/app/src/common/server/api.ts
@@ -92,7 +92,7 @@ export const api: Api = {
     },
 
     async deleteArticle(id) {
-        const response = await fetchWithLogin(`${apiRoot}/api/article/${id}`, { method: 'DELETE' });
+        const response = await fetchWithLogin(`${apiRoot}/api/article/${id}/delete`, { method: 'POST' });
         const data = await response.json<{ success: boolean, error: string }>();
         if (data.success) {
             return true;


### PR DESCRIPTION
# Remove DELETE verb
## Motivation

The article delete action used the `HTTP` `DELETE` verb.

For security reasons, the use of the `HTTP` `DELETE` verb is often forbidden by hosting administrators.

That is he case for our project hosting administrator.
## Action

I replaced the route `DELETE` `/api/article/:id` by the route `POST` `/api/article/:id/delete`.
